### PR TITLE
fix(prometheus): honor custom burn rate alerts

### DIFF
--- a/internal/prometheus/prometheus_rule_generator.go
+++ b/internal/prometheus/prometheus_rule_generator.go
@@ -412,6 +412,7 @@ func CreateAggregatedPrometheusRule(sloCompositionName, sloCompositionNamespace 
 		return monitoringv1.PrometheusRule{}, fmt.Errorf("unsupported composition type: %s", spec.Composition.Type)
 	}
 }
+
 func CreatePrometheusRule(sloName, sloNamespace string, objective observabilityv1alpha1.Objective) (monitoringv1.PrometheusRule, error) {
 	objectiveName := objective.Name
 

--- a/internal/prometheus/prometheus_rule_generator.go
+++ b/internal/prometheus/prometheus_rule_generator.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	observabilityv1alpha1 "github.com/federicolepera/slok/api/v1alpha1"
@@ -36,6 +37,73 @@ var defaultBurnRatePresets = []burnRatePreset{
 }
 
 const severityWarning = "warning"
+
+func parseAlertWindowHours(window string) (float64, error) {
+	if len(window) < 2 {
+		return 0, fmt.Errorf("invalid duration %q", window)
+	}
+
+	value, err := strconv.ParseFloat(window[:len(window)-1], 64)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("invalid duration %q", window)
+	}
+
+	switch window[len(window)-1] {
+	case 'd':
+		return value * 24, nil
+	case 'h':
+		return value, nil
+	case 'm':
+		return value / 60, nil
+	case 's':
+		return value / 3600, nil
+	default:
+		return 0, fmt.Errorf("invalid duration %q", window)
+	}
+}
+
+func burnRateThreshold(alert observabilityv1alpha1.BurnRateAlert, sloWindow string) (float64, error) {
+	sloWindowHours, err := parseAlertWindowHours(sloWindow)
+	if err != nil {
+		return 0, fmt.Errorf("invalid SLO window: %w", err)
+	}
+
+	consumeWindowHours, err := parseAlertWindowHours(alert.ConsumeWindow)
+	if err != nil {
+		return 0, fmt.Errorf("invalid consume window: %w", err)
+	}
+
+	return (alert.ConsumePercent / 100) * sloWindowHours / consumeWindowHours, nil
+}
+
+func burnRatePresetsForObjective(objective observabilityv1alpha1.Objective) ([]burnRatePreset, error) {
+	if objective.Alerting == nil ||
+		objective.Alerting.BurnRateAlerts == nil ||
+		len(objective.Alerting.BurnRateAlerts.Alerts) == 0 {
+		return defaultBurnRatePresets, nil
+	}
+
+	burnRates := objective.Alerting.BurnRateAlerts
+	presets := make([]burnRatePreset, 0, len(burnRates.Alerts))
+
+	for _, alert := range burnRates.Alerts {
+		threshold, err := burnRateThreshold(alert, objective.Window)
+		if err != nil {
+			return nil, fmt.Errorf("invalid burn-rate alert %q: %w", alert.Name, err)
+		}
+
+		presets = append(presets, burnRatePreset{
+			ShortWindow: alert.ShortWindow,
+			LongWindow:  alert.LongWindow,
+			BurnRate:    threshold,
+			Severity:    alert.Severity,
+			AlertSuffix: alert.Name,
+			For:         alert.ConsumeWindow,
+		})
+	}
+
+	return presets, nil
+}
 
 // Windows for which we generate recording rules
 var recordingWindows = []string{"5m", "1h", "6h", "3d", "7d", "30d"}
@@ -454,17 +522,22 @@ func CreatePrometheusRule(sloName, sloNamespace string, objective observabilityv
 		}
 	}
 
-	// Burn rate alerts using presets
+	// Burn rate alerts using defaults or custom objective config.
 	if objective.Alerting != nil && objective.Alerting.BurnRateAlerts != nil && objective.Alerting.BurnRateAlerts.Enabled {
 		alertGroup := monitoringv1.RuleGroup{
 			Name: fmt.Sprintf("slok.%s.%s-burnRateAlerts", sloName, objectiveName),
 		}
 
-		// Multi-window burn rate alerts from presets
-		for _, preset := range defaultBurnRatePresets {
+		presets, err := burnRatePresetsForObjective(objective)
+		if err != nil {
+			return monitoringv1.PrometheusRule{}, err
+		}
+
+		for _, preset := range presets {
 			alertGroup.Rules = append(alertGroup.Rules, monitoringv1.Rule{
 				Alert:  fmt.Sprintf("Objective: %s SLOBurnRateHigh - %s", objectiveName, preset.AlertSuffix),
 				Expr:   intstr.FromString(burnRateAlertExpr(sloName, sloNamespace, objectiveName, preset)),
+				For:    monitoringv1.DurationPointer(preset.For),
 				Labels: baseLabels(sloName, sloNamespace, objectiveName, preset.ShortWindow),
 			})
 			alertGroup.Rules[len(alertGroup.Rules)-1].Labels["severity"] = preset.Severity

--- a/internal/prometheus/prometheus_rule_generator_test.go
+++ b/internal/prometheus/prometheus_rule_generator_test.go
@@ -518,3 +518,137 @@ func TestCreateAggregatedPrometheusRule_WEIGHTED_ROUTES_UnknownAlias(t *testing.
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
+
+func TestCreatePrometheusRuleUsesCustomBurnRateAlerts(t *testing.T) {
+	objective := observabilityv1alpha1.Objective{
+		Name:   "availability",
+		Target: 99.9,
+		Window: "30d",
+		Sli: observabilityv1alpha1.SLI{
+			Query: &observabilityv1alpha1.Query{
+				TotalQuery: "http_requests_total",
+				ErrorQuery: `http_requests_total{status=~"5.."}`,
+			},
+		},
+		Alerting: &observabilityv1alpha1.Alerting{
+			BurnRateAlerts: &observabilityv1alpha1.BurnRates{
+				Enabled: true,
+				Alerts: []observabilityv1alpha1.BurnRateAlert{
+					{
+						Name:           "TicketPage",
+						ConsumePercent: 2,
+						ConsumeWindow:  "1h",
+						LongWindow:     "1h",
+						ShortWindow:    "5m",
+						Severity:       "critical",
+					},
+				},
+			},
+		},
+	}
+
+	rule, err := CreatePrometheusRule("checkout", "prod", objective)
+	if err != nil {
+		t.Fatalf("CreatePrometheusRule returned error: %v", err)
+	}
+
+	if len(rule.Spec.Groups) != 2 {
+		t.Fatalf("expected recording and alert groups, got %d groups", len(rule.Spec.Groups))
+	}
+
+	alertGroup := rule.Spec.Groups[1]
+	if len(alertGroup.Rules) != 2 {
+		t.Fatalf("expected one custom burn-rate alert plus budget-exhausted alert, got %d rules", len(alertGroup.Rules))
+	}
+
+	alert := alertGroup.Rules[0]
+	expr := alert.Expr.String()
+
+	if !strings.Contains(alert.Alert, "TicketPage") {
+		t.Fatalf("expected custom alert name to be used, got: %s", alert.Alert)
+	}
+	if !strings.Contains(expr, "slok:burn_rate:5m") {
+		t.Fatalf("expected custom short window in expression, got: %s", expr)
+	}
+	if !strings.Contains(expr, "slok:burn_rate:1h") {
+		t.Fatalf("expected custom long window in expression, got: %s", expr)
+	}
+	if !strings.Contains(expr, "> 14.4") {
+		t.Fatalf("expected threshold calculated from consumePercent/window, got: %s", expr)
+	}
+	if alert.Labels["severity"] != "critical" {
+		t.Fatalf("expected custom severity critical, got: %s", alert.Labels["severity"])
+	}
+	if alert.For == nil || *alert.For != "1h" {
+		t.Fatalf("expected alert for duration to come from custom consumeWindow, got: %v", alert.For)
+	}
+}
+
+func TestCreatePrometheusRuleDefaultBurnRateAlertsRemainWithoutCustomAlerts(t *testing.T) {
+	objective := observabilityv1alpha1.Objective{
+		Name:   "availability",
+		Target: 99.9,
+		Window: "30d",
+		Sli: observabilityv1alpha1.SLI{
+			Query: &observabilityv1alpha1.Query{
+				TotalQuery: "http_requests_total",
+				ErrorQuery: `http_requests_total{status=~"5.."}`,
+			},
+		},
+		Alerting: &observabilityv1alpha1.Alerting{
+			BurnRateAlerts: &observabilityv1alpha1.BurnRates{
+				Enabled: true,
+			},
+		},
+	}
+
+	rule, err := CreatePrometheusRule("checkout", "prod", objective)
+	if err != nil {
+		t.Fatalf("CreatePrometheusRule returned error: %v", err)
+	}
+
+	alertGroup := rule.Spec.Groups[1]
+	expectedRules := len(defaultBurnRatePresets) + 1
+	if len(alertGroup.Rules) != expectedRules {
+		t.Fatalf("expected %d default alert rules, got %d", expectedRules, len(alertGroup.Rules))
+	}
+
+	firstBurnRateAlert := alertGroup.Rules[0]
+	if firstBurnRateAlert.For == nil || *firstBurnRateAlert.For != defaultBurnRatePresets[0].For {
+		t.Fatalf("expected default alert for duration %q, got %v", defaultBurnRatePresets[0].For, firstBurnRateAlert.For)
+	}
+}
+
+func TestCreatePrometheusRuleRejectsInvalidCustomBurnRateWindow(t *testing.T) {
+	objective := observabilityv1alpha1.Objective{
+		Name:   "availability",
+		Target: 99.9,
+		Window: "30d",
+		Sli: observabilityv1alpha1.SLI{
+			Query: &observabilityv1alpha1.Query{
+				TotalQuery: "http_requests_total",
+				ErrorQuery: `http_requests_total{status=~"5.."}`,
+			},
+		},
+		Alerting: &observabilityv1alpha1.Alerting{
+			BurnRateAlerts: &observabilityv1alpha1.BurnRates{
+				Enabled: true,
+				Alerts: []observabilityv1alpha1.BurnRateAlert{
+					{
+						Name:           "BadWindow",
+						ConsumePercent: 2,
+						ConsumeWindow:  "soon",
+						LongWindow:     "1h",
+						ShortWindow:    "5m",
+						Severity:       "critical",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := CreatePrometheusRule("checkout", "prod", objective)
+	if err == nil {
+		t.Fatalf("expected invalid custom burn-rate window to return an error")
+	}
+}

--- a/internal/prometheus/prometheus_rule_generator_test.go
+++ b/internal/prometheus/prometheus_rule_generator_test.go
@@ -579,7 +579,7 @@ func TestCreatePrometheusRuleUsesCustomBurnRateAlerts(t *testing.T) {
 	if alert.Labels["severity"] != "critical" {
 		t.Fatalf("expected custom severity critical, got: %s", alert.Labels["severity"])
 	}
-	if alert.For == nil || *alert.For != "1h" {
+	if alert.For == nil || string(*alert.For) != "1h" {
 		t.Fatalf("expected alert for duration to come from custom consumeWindow, got: %v", alert.For)
 	}
 }
@@ -614,7 +614,7 @@ func TestCreatePrometheusRuleDefaultBurnRateAlertsRemainWithoutCustomAlerts(t *t
 	}
 
 	firstBurnRateAlert := alertGroup.Rules[0]
-	if firstBurnRateAlert.For == nil || *firstBurnRateAlert.For != defaultBurnRatePresets[0].For {
+	if firstBurnRateAlert.For == nil || string(*firstBurnRateAlert.For) != defaultBurnRatePresets[0].For {
 		t.Fatalf("expected default alert for duration %q, got %v", defaultBurnRatePresets[0].For, firstBurnRateAlert.For)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #27.

The CRD exposes custom burn-rate alert settings, but generated rules still used the built-in defaults. This makes custom burn-rate alerts drive the generated Prometheus rules when provided.

## What changed

- Added helper logic to convert custom burn-rate alert config into generator presets.
- Calculate the burn-rate threshold from:
  - `consumePercent`
  - objective `window`
  - alert `consumeWindow`
- Use custom:
  - alert name
  - short window
  - long window
  - severity
- Validate custom `shortWindow` and `longWindow` against the existing recording windows:
  - `5m`
  - `1h`
  - `6h`
  - `3d`
  - `7d`
  - `30d`
- Preserve existing default behavior when burn-rate alerts are enabled but no custom alerts are provided.
- Keep existing Prometheus `for` behavior unchanged in this PR.
- Added regression tests for:
  - custom alert generation
  - default fallback behavior
  - invalid custom `consumeWindow` handling
  - invalid custom `shortWindow`
  - invalid custom `longWindow`

## Why

A custom burn-rate alert can only reference recording rules that actually exist.

The generator creates `slok:burn_rate:<window>` recording rules only for the existing `recordingWindows` list:

```text
5m, 1h, 6h, 3d, 7d, 30d